### PR TITLE
[wip] Add release manifests

### DIFF
--- a/openshift/patches/001-networkpolicy-mesh.patch
+++ b/openshift/patches/001-networkpolicy-mesh.patch
@@ -1,0 +1,69 @@
+diff --git a/openshift/release/artifacts/0-networkpolicy-mesh.yaml b/openshift/release/artifacts/0-networkpolicy-mesh.yaml
+new file mode 100644
+index 00000000..3d46fbed
+--- /dev/null
++++ b/openshift/release/artifacts/0-networkpolicy-mesh.yaml
+@@ -0,0 +1,63 @@
++apiVersion: networking.k8s.io/v1
++kind: NetworkPolicy
++metadata:
++  name: webhook
++  labels:
++    app: webhook
++    serving.knative.dev/release: devel
++    networking.knative.dev/ingress-provider: istio
++spec:
++  podSelector:
++    matchLabels:
++      app: webhook
++  ingress:
++  - {}
++---
++apiVersion: networking.k8s.io/v1
++kind: NetworkPolicy
++metadata:
++  name: net-istio-webhook
++  labels:
++    app: net-istio-webhook
++    serving.knative.dev/release: devel
++    networking.knative.dev/ingress-provider: istio
++spec:
++  podSelector:
++    matchLabels:
++      app: net-istio-webhook
++  ingress:
++  - {}
++---
++apiVersion: networking.k8s.io/v1
++kind: NetworkPolicy
++metadata:
++  name: domainmapping-webhook
++  labels:
++    app: domainmapping-webhook
++    serving.knative.dev/release: devel
++    networking.knative.dev/ingress-provider: istio
++spec:
++  podSelector:
++    matchLabels:
++      app: domainmapping-webhook
++  ingress:
++  - {}
++---
++apiVersion: networking.k8s.io/v1
++kind: NetworkPolicy
++metadata:
++  name: allow-from-openshift-monitoring-ns
++  namespace: knative-serving
++  labels:
++    serving.knative.dev/release: devel
++    networking.knative.dev/ingress-provider: istio
++spec:
++  ingress:
++  - from:
++    - namespaceSelector:
++        matchLabels:
++          name: "openshift-monitoring"
++  podSelector: {}
++  policyTypes:
++  - Ingress
++---

--- a/openshift/release/artifacts/0-networkpolicy-mesh.yaml
+++ b/openshift/release/artifacts/0-networkpolicy-mesh.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook
+  labels:
+    app: webhook
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  podSelector:
+    matchLabels:
+      app: webhook
+  ingress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: net-istio-webhook
+  labels:
+    app: net-istio-webhook
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  podSelector:
+    matchLabels:
+      app: net-istio-webhook
+  ingress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: domainmapping-webhook
+  labels:
+    app: domainmapping-webhook
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  podSelector:
+    matchLabels:
+      app: domainmapping-webhook
+  ingress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-monitoring-ns
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: "openshift-monitoring"
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---

--- a/openshift/release/artifacts/1-200-clusterrole.yaml
+++ b/openshift/release/artifacts/1-200-clusterrole.yaml
@@ -1,0 +1,30 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # These are the permissions needed by the Istio Ingress implementation.
+  name: knative-serving-istio
+  labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
+    serving.knative.dev/controller: "true"
+    networking.knative.dev/ingress-provider: istio
+rules:
+  - apiGroups: ["networking.istio.io"]
+    resources: ["virtualservices", "gateways", "destinationrules"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]

--- a/openshift/release/artifacts/2-400-config-istio.yaml
+++ b/openshift/release/artifacts/2-400-config-istio.yaml
@@ -1,0 +1,78 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-istio
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+data:
+  # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
+
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # A gateway and Istio service to serve external traffic.
+    # The configuration format should be
+    # `gateway.{{gateway_namespace}}.{{gateway_name}}: "{{ingress_name}}.{{ingress_namespace}}.svc.cluster.local"`.
+    # The {{gateway_namespace}} is optional; when it is omitted, the system will search for
+    # the gateway in the serving system namespace `knative-serving`
+    gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+
+    # A cluster local gateway to allow pods outside of the mesh to access
+    # Services and Routes not exposing through an ingress.  If the users
+    # do have a service mesh setup, this isn't required and can be removed.
+    #
+    # An example use case is when users want to use Istio without any
+    # sidecar injection (like Knative's istio-ci-no-mesh.yaml).  Since every pod
+    # is outside of the service mesh in that case, a cluster-local  service
+    # will need to be exposed to a cluster-local gateway to be accessible.
+    # The configuration format should be `local-gateway.{{local_gateway_namespace}}.
+    # {{local_gateway_name}}: "{{cluster_local_gateway_name}}.
+    # {{cluster_local_gateway_namespace}}.svc.cluster.local"`. The
+    # {{local_gateway_namespace}} is optional; when it is omitted, the system
+    # will search for the local gateway in the serving system namespace
+    # `knative-serving`
+    local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.istio-system.svc.cluster.local"
+
+    # DEPRECATED: local-gateway.mesh is deprecated.
+    # See: https://github.com/knative/serving/issues/11523
+    #
+    # To use only Istio service mesh and no knative-local-gateway, replace
+    # all local-gateway.* entries by the following entry.
+    local-gateway.mesh: "mesh"
+
+    # If true, knative will use the Istio VirtualService's status to determine
+    # endpoint readiness. Otherwise, probe as usual.
+    # NOTE: This feature is currently experimental and should not be used in production.
+    enable-virtualservice-status: "false"

--- a/openshift/release/artifacts/3-500-controller.yaml
+++ b/openshift/release/artifacts/3-500-controller.yaml
@@ -1,0 +1,89 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: net-istio-controller
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    matchLabels:
+      app: net-istio-controller
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        # This must be outside of the mesh to probe the gateways.
+        # NOTE: this is allowed here and not elsewhere because
+        # this is the Istio controller, and so it may be Istio-aware.
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: net-istio-controller
+        app.kubernetes.io/component: net-istio
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: devel
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: controller
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: ko://knative.dev/net-istio/cmd/controller
+
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+
+        # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+        - name: METRICS_DOMAIN
+          value: knative.dev/net-istio
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
+
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+
+# Unlike other controllers, this doesn't need a Service defined for metrics and
+# profiling because it opts out of the mesh (see annotation above).

--- a/openshift/release/artifacts/4-500-webhook-deployment.yaml
+++ b/openshift/release/artifacts/4-500-webhook-deployment.yaml
@@ -1,0 +1,83 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: net-istio-webhook
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    matchLabels:
+      app: net-istio-webhook
+      role: net-istio-webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: net-istio-webhook
+        role: net-istio-webhook
+        app.kubernetes.io/component: net-istio
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: devel
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: webhook
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: ko://knative.dev/net-istio/cmd/webhook
+
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+
+        # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+        - name: METRICS_DOMAIN
+          value: knative.dev/net-istio
+        - name: WEBHOOK_NAME
+          value: net-istio-webhook
+
+        securityContext:
+          allowPrivilegeEscalation: false
+
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: https-webhook
+          containerPort: 8443

--- a/openshift/release/artifacts/5-500-webhook-secret.yaml
+++ b/openshift/release/artifacts/5-500-webhook-secret.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: net-istio-webhook-certs
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio

--- a/openshift/release/artifacts/6-500-webhook-service.yaml
+++ b/openshift/release/artifacts/6-500-webhook-service.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: net-istio-webhook
+  namespace: knative-serving
+  labels:
+    role: net-istio-webhook
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  ports:
+  # Define metrics and profiling for them to be accessible within service meshes.
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    app: net-istio-webhook

--- a/openshift/release/artifacts/7-600-mutating-webhook.yaml
+++ b/openshift/release/artifacts/7-600-mutating-webhook.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.istio.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: net-istio-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  objectSelector:
+    matchExpressions:
+      - {key: "serving.knative.dev/configuration", operator: Exists}
+  name: webhook.istio.networking.internal.knative.dev

--- a/openshift/release/artifacts/8-600-validating-webhook.yaml
+++ b/openshift/release/artifacts/8-600-validating-webhook.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.istio.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: net-istio-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: config.webhook.istio.networking.internal.knative.dev
+  objectSelector:
+    matchLabels:
+      app.kubernetes.io/name: knative-serving
+      app.kubernetes.io/component: net-istio

--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Usage example: ./download_release_artifacts.sh v1.3.0
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+patches_path="${SCRIPT_DIR}/../patches"
+artifacts_path="${SCRIPT_DIR}/artifacts"
+mkdir -p "${patches_path}"
+mkdir -p "${artifacts_path}"
+# These files could in theory change from release to release, though their names should
+# be fairly stable.
+istio_files=(200-clusterrole 400-config-istio 500-controller 500-webhook-deployment 500-webhook-secret 500-webhook-service 600-mutating-webhook 600-validating-webhook)
+
+function download_ingress {
+  component=$1
+  version=$2
+  shift
+  shift
+
+  files=("$@")
+
+  component_dir="${artifacts_path}"
+  release_suffix="${version%?}0"
+  target_dir="${component_dir}"
+  rm -r "$component_dir"
+  mkdir -p "$target_dir"
+
+  for (( i=0; i<${#files[@]}; i++ ));
+  do
+    index=$(( i+1 ))
+    file="${files[$i]}.yaml"
+    target_file="$target_dir/$index-$file"
+
+    url="https://raw.githubusercontent.com/knative-sandbox/${component}/knative-${version}/config/${file}"
+    wget --no-check-certificate "$url" -O "$target_file"
+  done
+}
+
+download_ingress net-istio "$1" "${istio_files[@]}"
+
+# Add networkpolicy for webhook when net-istio is enabled.
+git apply "${patches_path}/001-networkpolicy-mesh.patch"


### PR DESCRIPTION
* Part of the SIG release work
* Tested at https://github.com/openshift-knative/serverless-operator/pull/1642
* Adds openshift folder as in other midstream repos. Plan is to automate this for each new release branch cut upstream.