### PR TITLE
[SRVKS-1028] Use `kubernetes.io/metadata.name` for the namespace selector label

### DIFF
--- a/openshift/release/extra/0-networkpolicy-mesh.yaml
+++ b/openshift/release/extra/0-networkpolicy-mesh.yaml
@@ -56,7 +56,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: "openshift-monitoring"
+          kubernetes.io/metadata.name: "openshift-monitoring"
   podSelector: {}
   policyTypes:
   - Ingress


### PR DESCRIPTION
As per title, this patch changes to use the `kubernetes.io/metadata.name` for the namespace label because because it is enforced by the API server: https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name