### PR TITLE
[SRVKS-1047] Add non-seccomp patch to drop RuntimeDefault

### DIFF
--- a/openshift/patches/001-nonseccomp.patch
+++ b/openshift/patches/001-nonseccomp.patch
@@ -1,0 +1,26 @@
+diff --git a/config/500-controller.yaml b/config/500-controller.yaml
+index 892ab1f2..334e1306 100644
+--- a/config/500-controller.yaml
++++ b/config/500-controller.yaml
+@@ -78,8 +78,6 @@ spec:
+           capabilities:
+             drop:
+               - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+ 
+         ports:
+         - name: metrics
+diff --git a/config/500-webhook-deployment.yaml b/config/500-webhook-deployment.yaml
+index 156bffee..eb14e21d 100644
+--- a/config/500-webhook-deployment.yaml
++++ b/config/500-webhook-deployment.yaml
+@@ -75,8 +75,6 @@ spec:
+           capabilities:
+             drop:
+               - ALL
+-          seccompProfile:
+-            type: RuntimeDefault
+ 
+         ports:
+         - name: metrics

--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -50,5 +50,7 @@ mkdir -p "$YAML_OUTPUT_DIR"
 
 patches_path="${SCRIPT_DIR}/../patches"
 
+git apply "${patches_path}"/*
+
 resolve_resources "config/" "$NET_ISTIO_YAML"
 resolve_resources "openshift/release/extra/" "$NETWORK_POLICY_YAML"


### PR DESCRIPTION
As per title, this patch fixes SRVKS-1047.

Note, this patch can be dropped once 4.10 support ends [SRVKS-1048](https://issues.redhat.com/browse/SRVKS-1048).