### PR TITLE
[RELEASE-1.8] [SRVKS-1046] Add missing probes

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -84,6 +84,7 @@ func main() {
 		Port:        8443,
 	})
 
+	ctx = sharedmain.WithHealthProbesDisabled(ctx)
 	sharedmain.WebhookMainWithContext(
 		ctx, "net-istio-webhook",
 		certificates.NewController,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -84,7 +84,6 @@ func main() {
 		Port:        8443,
 	})
 
-	ctx = sharedmain.WithHealthProbesDisabled(ctx)
 	sharedmain.WebhookMainWithContext(
 		ctx, "net-istio-webhook",
 		certificates.NewController,

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -79,11 +79,28 @@ spec:
             drop:
               - ALL
 
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 6
+
         ports:
         - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        - name: probes
+          containerPort: 8080
 
 # Unlike other controllers, this doesn't need a Service defined for metrics and
 # profiling because it opts out of the mesh (see annotation above).

--- a/config/500-webhook-deployment.yaml
+++ b/config/500-webhook-deployment.yaml
@@ -76,6 +76,26 @@ spec:
             drop:
               - ALL
 
+        readinessProbe:
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+              - name: k-kubelet-probe
+                value: "webhook"
+          failureThreshold: 3
+        livenessProbe:
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+              - name: k-kubelet-probe
+                value: "webhook"
+          failureThreshold: 6
+          initialDelaySeconds: 20
+
         ports:
         - name: metrics
           containerPort: 9090


### PR DESCRIPTION
- Backport of https://github.com/knative-sandbox/net-istio/pull/1095, no need to disable the default probes for sharedmain as they are not available on the branch.