### PR TITLE
[RELEASE-1.8] Add default health checks for sharedmain

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -84,6 +84,7 @@ func main() {
 		Port:        8443,
 	})
 
+	ctx = sharedmain.WithHealthProbesDisabled(ctx)
 	sharedmain.WebhookMainWithContext(
 		ctx, "net-istio-webhook",
 		certificates.NewController,

--- a/vendor/knative.dev/pkg/injection/health_check.go
+++ b/vendor/knative.dev/pkg/injection/health_check.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injection
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"knative.dev/pkg/logging"
+)
+
+// HealthCheckDefaultPort defines the default port number for health probes
+const HealthCheckDefaultPort = 8080
+
+// ServeHealthProbes sets up liveness and readiness probes.
+// If user sets no probes explicitly via the context then defaults are added.
+func ServeHealthProbes(ctx context.Context, port int) error {
+	logger := logging.FromContext(ctx)
+	server := http.Server{ReadHeaderTimeout: time.Minute, Handler: muxWithHandles(ctx), Addr: ":" + strconv.Itoa(port)}
+	go func() {
+		<-ctx.Done()
+		_ = server.Shutdown(ctx)
+	}()
+
+	// start the web server on port and accept requests
+	logger.Infof("Probes server listening on port %d", port)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func muxWithHandles(ctx context.Context) *http.ServeMux {
+	mux := http.NewServeMux()
+	readiness := getReadinessHandleOrDefault(ctx)
+	liveness := getLivenessHandleOrDefault(ctx)
+	mux.HandleFunc("/readiness", *readiness)
+	mux.HandleFunc("/health", *liveness)
+	return mux
+}
+
+func newDefaultProbesHandle(sigCtx context.Context) http.HandlerFunc {
+	logger := logging.FromContext(sigCtx)
+	return func(w http.ResponseWriter, r *http.Request) {
+		f := func() error {
+			select {
+			// When we get SIGTERM (sigCtx done), let readiness probes start failing.
+			case <-sigCtx.Done():
+				logger.Info("Signal context canceled")
+				return errors.New("received SIGTERM from kubelet")
+			default:
+				return nil
+			}
+		}
+		if err := f(); err != nil {
+			logger.Errorf("Healthcheck failed: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}
+
+type addReadinessKey struct{}
+
+// AddReadiness signals to probe setup logic to add a user provided probe handler
+func AddReadiness(ctx context.Context, handlerFunc http.HandlerFunc) context.Context {
+	return context.WithValue(ctx, addReadinessKey{}, &handlerFunc)
+}
+
+func getReadinessHandleOrDefault(ctx context.Context) *http.HandlerFunc {
+	if ctx.Value(addReadinessKey{}) != nil {
+		return ctx.Value(addReadinessKey{}).(*http.HandlerFunc)
+	}
+	defaultHandle := newDefaultProbesHandle(ctx)
+	return &defaultHandle
+}
+
+type addLivenessKey struct{}
+
+// AddLiveness signals to probe setup logic to add a user provided probe handler
+func AddLiveness(ctx context.Context, handlerFunc http.HandlerFunc) context.Context {
+	return context.WithValue(ctx, addLivenessKey{}, &handlerFunc)
+}
+
+func getLivenessHandleOrDefault(ctx context.Context) *http.HandlerFunc {
+	if ctx.Value(addLivenessKey{}) != nil {
+		return ctx.Value(addLivenessKey{}).(*http.HandlerFunc)
+	}
+	defaultHandle := newDefaultProbesHandle(ctx)
+	return &defaultHandle
+}

--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -292,6 +292,13 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 		return controller.StartAll(ctx, controllers...)
 	})
 
+	// Setup default health checks to catch issues with cache sync etc.
+	if !healthProbesDisabled(ctx) {
+		eg.Go(func() error {
+			return injection.ServeHealthProbes(ctx, injection.HealthCheckDefaultPort)
+		})
+	}
+
 	// This will block until either a signal arrives or one of the grouped functions
 	// returns an error.
 	<-egCtx.Done()
@@ -301,6 +308,17 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	if err := eg.Wait(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.Errorw("Error while running server", zap.Error(err))
 	}
+}
+
+type healthProbesDisabledKey struct{}
+
+// WithHealthProbesDisabled signals to MainWithContext that it should disable default probes (readiness and liveness).
+func WithHealthProbesDisabled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, healthProbesDisabledKey{}, struct{}{})
+}
+
+func healthProbesDisabled(ctx context.Context) bool {
+	return ctx.Value(healthProbesDisabledKey{}) != nil
 }
 
 func flush(logger *zap.SugaredLogger) {


### PR DESCRIPTION
- The net-kourier-controller probes rely on the sharedmain default probes that are not backported (https://github.com/knative/pkg/pull/2671).
- We should cherry-pick to 1.9.