### PR TITLE
[RELEASE-v1.9] add maistra annotation to generated gateways to disable IOR

### DIFF
--- a/openshift/patches/002-add-maistra-annotation.patch
+++ b/openshift/patches/002-add-maistra-annotation.patch
@@ -1,0 +1,96 @@
+diff --git a/pkg/reconciler/ingress/resources/gateway_test.go b/pkg/reconciler/ingress/resources/gateway_test.go
+--- a/pkg/reconciler/ingress/resources/gateway_test.go	(revision e29c53793c5f9285867a4b212bfb771f2cc4d498)
++++ b/pkg/reconciler/ingress/resources/gateway_test.go	(date 1689754206463)
+@@ -593,6 +593,7 @@
+ 				Name:            WildcardGatewayName(wildcardSecret.Name, "istio-system", "istio-ingressgateway"),
+ 				Namespace:       system.Namespace(),
+ 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
++				Annotations:     map[string]string{maistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1alpha3.Gateway{
+ 				Selector: selector,
+@@ -630,6 +631,7 @@
+ 				Name:            WildcardGatewayName(wildcardSecret.Name, system.Namespace(), "istio-ingressgateway"),
+ 				Namespace:       system.Namespace(),
+ 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
++				Annotations:     map[string]string{maistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1alpha3.Gateway{
+ 				Selector: selector,
+@@ -743,6 +745,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1alpha3.Gateway{
+ 				Selector: selector,
+@@ -761,6 +764,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1alpha3.Gateway{
+ 				Selector: selector,
+@@ -824,6 +828,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1alpha3.Gateway{
+ 				Selector: selector,
+@@ -866,6 +871,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1alpha3.Gateway{
+ 				Selector: selector,
+@@ -908,6 +914,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress.com",
+ 				},
++				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1alpha3.Gateway{
+ 				Selector: selector,
+diff --git a/pkg/reconciler/ingress/resources/gateway.go b/pkg/reconciler/ingress/resources/gateway.go
+--- a/pkg/reconciler/ingress/resources/gateway.go	(revision e29c53793c5f9285867a4b212bfb771f2cc4d498)
++++ b/pkg/reconciler/ingress/resources/gateway.go	(date 1689754009081)
+@@ -42,9 +42,10 @@
+
+ // GatewayHTTPPort is the HTTP port the gateways listen on.
+ const (
+-	GatewayHTTPPort       = 80
+-	dns1123LabelMaxLength = 63 // Public for testing only.
+-	dns1123LabelFmt       = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
++	GatewayHTTPPort                 = 80
++	dns1123LabelMaxLength           = 63 // Public for testing only.
++	dns1123LabelFmt                 = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
++	maistraManageRouteAnnotationKey = "maistra.io/manageRoute"
+ )
+
+ var httpServerPortName = "http-server"
+@@ -199,6 +200,9 @@
+ 				Name:            WildcardGatewayName(secret.Name, gatewayService.Namespace, gatewayService.Name),
+ 				Namespace:       secret.Namespace,
+ 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(secret, gvk)},
++				Annotations: map[string]string{
++					maistraManageRouteAnnotationKey: "false",
++				},
+ 			},
+ 			Spec: istiov1alpha3.Gateway{
+ 				Selector: gatewayService.Spec.Selector,
+@@ -254,6 +258,9 @@
+ 				// We need this label to find out all of Gateways of a given Ingress.
+ 				networking.IngressLabelKey: ing.GetName(),
+ 			},
++			Annotations: map[string]string{
++				maistraManageRouteAnnotationKey: "false",
++			},
+ 		},
+ 		Spec: istiov1alpha3.Gateway{
+ 			Selector: selector,

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -42,9 +42,10 @@ import (
 
 // GatewayHTTPPort is the HTTP port the gateways listen on.
 const (
-	GatewayHTTPPort       = 80
-	dns1123LabelMaxLength = 63 // Public for testing only.
-	dns1123LabelFmt       = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
+	GatewayHTTPPort                 = 80
+	dns1123LabelMaxLength           = 63 // Public for testing only.
+	dns1123LabelFmt                 = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
+	maistraManageRouteAnnotationKey = "maistra.io/manageRoute"
 )
 
 var httpServerPortName = "http-server"
@@ -199,6 +200,9 @@ func makeWildcardTLSGateways(originWildcardSecrets map[string]*corev1.Secret,
 				Name:            WildcardGatewayName(secret.Name, gatewayService.Namespace, gatewayService.Name),
 				Namespace:       secret.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(secret, gvk)},
+				Annotations: map[string]string{
+					maistraManageRouteAnnotationKey: "false",
+				},
 			},
 			Spec: istiov1alpha3.Gateway{
 				Selector: gatewayService.Spec.Selector,
@@ -253,6 +257,9 @@ func makeIngressGateway(ing *v1alpha1.Ingress, selector map[string]string, serve
 			Labels: map[string]string{
 				// We need this label to find out all of Gateways of a given Ingress.
 				networking.IngressLabelKey: ing.GetName(),
+			},
+			Annotations: map[string]string{
+				maistraManageRouteAnnotationKey: "false",
 			},
 		},
 		Spec: istiov1alpha3.Gateway{

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -593,6 +593,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 				Name:            WildcardGatewayName(wildcardSecret.Name, "istio-system", "istio-ingressgateway"),
 				Namespace:       system.Namespace(),
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
+				Annotations:     map[string]string{maistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1alpha3.Gateway{
 				Selector: selector,
@@ -630,6 +631,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 				Name:            WildcardGatewayName(wildcardSecret.Name, system.Namespace(), "istio-ingressgateway"),
 				Namespace:       system.Namespace(),
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
+				Annotations:     map[string]string{maistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1alpha3.Gateway{
 				Selector: selector,
@@ -743,6 +745,7 @@ func TestMakeIngressGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1alpha3.Gateway{
 				Selector: selector,
@@ -761,6 +764,7 @@ func TestMakeIngressGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1alpha3.Gateway{
 				Selector: selector,
@@ -824,6 +828,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1alpha3.Gateway{
 				Selector: selector,
@@ -866,6 +871,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1alpha3.Gateway{
 				Selector: selector,
@@ -908,6 +914,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress.com",
 				},
+				Annotations: map[string]string{maistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1alpha3.Gateway{
 				Selector: selector,


### PR DESCRIPTION
## Changes
- add maistra annotation to generated gateways to disable IOR generation of OCP Routes

JIRA: https://issues.redhat.com/browse/SRVKS-1099

/assign @nak3 @skonto 

I'll also cherry-pick this to 1.10 and main.