### PR TITLE
Upstream `create-release-branch.sh` to use correct branch

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -16,11 +16,11 @@ set -e # Exit immediately on error.
 release=$1
 
 # Set upstream release without "v" prefix. e.g. release-v1.11 => release-1.11
-upstream_release=release-${release#"release-v"}
+upstream_release=release-"${release#"release-v"}"
 
 # Fetch the latest upstream and checkout the new branch.
-git fetch upstream ${upstream_release}
-git checkout upstream/${upstream_release}
+git fetch upstream "${upstream_release}"
+git checkout upstream/"${upstream_release}"
 
 # Copy the openshift extra files from the OPENSHIFT/main branch.
 git fetch openshift main
@@ -28,7 +28,7 @@ git checkout openshift/main -- openshift OWNERS
 git add openshift OWNERS
 git commit -m "Add openshift specific files."
 
-openshift/release/download_release_artifacts.sh ${release}
+openshift/release/download_release_artifacts.sh "${release}"
 git add .
 git commit -am ":fire: Generate artifacts."
 

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -15,9 +15,12 @@ set -e # Exit immediately on error.
 
 release=$1
 
+# Set upstream release without "v" prefix. e.g. release-v1.11 => release-1.11
+upstream_release=release-${release#"release-v"}
+
 # Fetch the latest upstream and checkout the new branch.
-git fetch upstream ${release}
-git checkout upstream/${release}
+git fetch upstream ${upstream_release}
+git checkout upstream/${upstream_release}
 
 # Copy the openshift extra files from the OPENSHIFT/main branch.
 git fetch openshift main
@@ -25,11 +28,7 @@ git checkout openshift/main -- openshift OWNERS
 git add openshift OWNERS
 git commit -m "Add openshift specific files."
 
-# Drop the release-suffix and add the micro version with '0'.
-# e.g. release-1.9 => 1.9.0
-VERSION=${release#"release-"}.0
-
-openshift/release/download_release_artifacts.sh ${VERSION}
+openshift/release/download_release_artifacts.sh ${release}
 git add .
 git commit -am ":fire: Generate artifacts."
 
@@ -37,6 +36,7 @@ git commit -am ":fire: Generate artifacts."
 echo "
 Now ready to create a new branch. Push it by:
 
+  $ git checkout -b ${release}
   $ git push openshift ${release}
 
 "


### PR DESCRIPTION
This is same with https://github.com/openshift-knative/net-kourier/pull/92

There are two changes in this PR.

Recently we added `v` prefix for downstream branch but upstream does not have it.
Hence, we need the following line:

```sh
upstream_release=release-${release#"release-v"}
```

Also, the downstream's version label is equal to branch name so it should be:

```sh
openshift/release/download_release_artifacts.sh ${release}
```
