### PR TITLE
Drop network-policy for domain-mapping-webhook

### DIFF
--- a/openshift/release/extra/net-istio-netpolicies-mesh.yaml
+++ b/openshift/release/extra/net-istio-netpolicies-mesh.yaml
@@ -31,21 +31,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: domainmapping-webhook
-  labels:
-    app: domainmapping-webhook
-    app.kubernetes.io/version: devel
-    networking.knative.dev/ingress-provider: istio
-spec:
-  podSelector:
-    matchLabels:
-      app: domainmapping-webhook
-  ingress:
-  - {}
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
   name: allow-from-openshift-monitoring-ns
   namespace: knative-serving
   labels:


### PR DESCRIPTION
# Changes
- Drop network-policy for domain-mapping-webhook

/assign @nak3 
/assign @skonto 
