### PR TITLE
[release-v1.9] Allow to disable http2 for the webhook

### DIFF
--- a/openshift/patches/003-http2-cve.patch
+++ b/openshift/patches/003-http2-cve.patch
@@ -1,0 +1,44 @@
+diff --git a/vendor/knative.dev/pkg/webhook/webhook.go b/vendor/knative.dev/pkg/webhook/webhook.go
+index 435dfe38..00fcd3c4 100644
+--- a/vendor/knative.dev/pkg/webhook/webhook.go
++++ b/vendor/knative.dev/pkg/webhook/webhook.go
+@@ -63,6 +63,17 @@ type Options struct {
+ 	// GracePeriod is how long to wait after failing readiness probes
+ 	// before shutting down.
+ 	GracePeriod time.Duration
++
++	// EnableHTTP2 enables HTTP2 for webhooks.
++	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
++	// standard library and golang.org/x/net are fully fixed.
++	// Right now, it is possible for authenticated and unauthenticated users to
++	// hold open HTTP2 connections and consume huge amounts of memory.
++	// See:
++	// * https://github.com/kubernetes/kubernetes/pull/121120
++	// * https://github.com/kubernetes/kubernetes/issues/121197
++	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
++	EnableHTTP2 bool
+ }
+ 
+ // Operation is the verb being operated on
+@@ -208,11 +219,18 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
+ 		QuietPeriod: wh.Options.GracePeriod,
+ 	}
+ 
++	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
++	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
++	if wh.Options.EnableHTTP2 {
++		nextProto = nil
++	}
++
+ 	//nolint:gosec
+ 	server := &http.Server{
+-		Handler:   drainer,
+-		Addr:      fmt.Sprint(":", wh.Options.Port),
+-		TLSConfig: wh.tlsConfig,
++		Handler:      drainer,
++		Addr:         fmt.Sprint(":", wh.Options.Port),
++		TLSConfig:    wh.tlsConfig,
++		TLSNextProto: nextProto,
+ 	}
+ 
+ 	eg, ctx := errgroup.WithContext(ctx)

--- a/vendor/knative.dev/pkg/webhook/webhook.go
+++ b/vendor/knative.dev/pkg/webhook/webhook.go
@@ -63,6 +63,17 @@ type Options struct {
 	// GracePeriod is how long to wait after failing readiness probes
 	// before shutting down.
 	GracePeriod time.Duration
+
+	// EnableHTTP2 enables HTTP2 for webhooks.
+	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
+	// standard library and golang.org/x/net are fully fixed.
+	// Right now, it is possible for authenticated and unauthenticated users to
+	// hold open HTTP2 connections and consume huge amounts of memory.
+	// See:
+	// * https://github.com/kubernetes/kubernetes/pull/121120
+	// * https://github.com/kubernetes/kubernetes/issues/121197
+	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
+	EnableHTTP2 bool
 }
 
 // Operation is the verb being operated on
@@ -208,11 +219,18 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 		QuietPeriod: wh.Options.GracePeriod,
 	}
 
+	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
+	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
+	if wh.Options.EnableHTTP2 {
+		nextProto = nil
+	}
+
 	//nolint:gosec
 	server := &http.Server{
-		Handler:   drainer,
-		Addr:      fmt.Sprint(":", wh.Options.Port),
-		TLSConfig: wh.tlsConfig,
+		Handler:      drainer,
+		Addr:         fmt.Sprint(":", wh.Options.Port),
+		TLSConfig:    wh.tlsConfig,
+		TLSNextProto: nextProto,
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
This patch cherry-picks knative/pkg@b8c14ce against 1.9 as a patch.