### PR TITLE
[RELEASE-1.13] Back-port https://github.com/knative-extensions/net-istio/pull/1228

### DIFF
--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -55,3 +55,6 @@ spec:
     - name: http2
       port: 80
       targetPort: 8081
+    - name: https
+      port: 443
+      targetPort: 8444

--- a/openshift/patches/002-add-maistra-annotation.patch
+++ b/openshift/patches/002-add-maistra-annotation.patch
@@ -1,21 +1,27 @@
 diff --git a/pkg/reconciler/ingress/resources/gateway.go b/pkg/reconciler/ingress/resources/gateway.go
---- a/pkg/reconciler/ingress/resources/gateway.go	(revision 9914eca315000a757b0f48df69f59cdbb8f7ea23)
-+++ b/pkg/reconciler/ingress/resources/gateway.go	(revision 2b701027bfe7dca09d27c709b0cc5d66069a1f5b)
-@@ -42,9 +42,10 @@
+--- a/pkg/reconciler/ingress/resources/gateway.go	(revision 2971960b1cf6f44bbf9146e22d0e31eb253d812f)
++++ b/pkg/reconciler/ingress/resources/gateway.go	(date 1707288992469)
+@@ -41,12 +41,13 @@
+ )
 
- // GatewayHTTPPort is the HTTP port the gateways listen on.
  const (
--	GatewayHTTPPort       = 80
--	dns1123LabelMaxLength = 63 // Public for testing only.
--	dns1123LabelFmt       = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
+-	GatewayHTTPPort              = 80
+-	ExternalGatewayHTTPSPort     = 443
+-	ClusterLocalGatewayHTTPSPort = 8444
+-	dns1123LabelMaxLength        = 63 // Public for testing only.
+-	dns1123LabelFmt              = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
+-	localGatewayPostfix          = "-local"
 +	GatewayHTTPPort                 = 80
++	ExternalGatewayHTTPSPort        = 443
++	ClusterLocalGatewayHTTPSPort    = 8444
 +	dns1123LabelMaxLength           = 63 // Public for testing only.
 +	dns1123LabelFmt                 = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
++	localGatewayPostfix             = "-local"
 +	MaistraManageRouteAnnotationKey = "maistra.io/manageRoute"
  )
 
  var httpServerPortName = "http-server"
-@@ -199,6 +200,9 @@
+@@ -202,6 +203,9 @@
  				Name:            WildcardGatewayName(secret.Name, gatewayService.Namespace, gatewayService.Name),
  				Namespace:       secret.Namespace,
  				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(secret, gvk)},
@@ -25,8 +31,8 @@ diff --git a/pkg/reconciler/ingress/resources/gateway.go b/pkg/reconciler/ingres
  			},
  			Spec: istiov1beta1.Gateway{
  				Selector: gatewayService.Spec.Selector,
-@@ -254,6 +258,9 @@
- 				// We need this label to find out all of Gateways of a given Ingress.
+@@ -257,6 +261,9 @@
+ 				// We need this label to find out all Gateways of a given Ingress.
  				networking.IngressLabelKey: ing.GetName(),
  			},
 +			Annotations: map[string]string{
@@ -35,69 +41,10 @@ diff --git a/pkg/reconciler/ingress/resources/gateway.go b/pkg/reconciler/ingres
  		},
  		Spec: istiov1beta1.Gateway{
  			Selector: selector,
-diff --git a/pkg/reconciler/ingress/resources/gateway_test.go b/pkg/reconciler/ingress/resources/gateway_test.go
---- a/pkg/reconciler/ingress/resources/gateway_test.go	(revision 9914eca315000a757b0f48df69f59cdbb8f7ea23)
-+++ b/pkg/reconciler/ingress/resources/gateway_test.go	(revision 2b701027bfe7dca09d27c709b0cc5d66069a1f5b)
-@@ -593,6 +593,7 @@
- 				Name:            WildcardGatewayName(wildcardSecret.Name, "istio-system", "istio-ingressgateway"),
- 				Namespace:       system.Namespace(),
- 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
-+				Annotations:     map[string]string{MaistraManageRouteAnnotationKey: "false"},
- 			},
- 			Spec: istiov1beta1.Gateway{
- 				Selector: selector,
-@@ -630,6 +631,7 @@
- 				Name:            WildcardGatewayName(wildcardSecret.Name, system.Namespace(), "istio-ingressgateway"),
- 				Namespace:       system.Namespace(),
- 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
-+				Annotations:     map[string]string{MaistraManageRouteAnnotationKey: "false"},
- 			},
- 			Spec: istiov1beta1.Gateway{
- 				Selector: selector,
-@@ -743,6 +745,7 @@
- 				Labels: map[string]string{
- 					networking.IngressLabelKey: "ingress",
- 				},
-+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
- 			},
- 			Spec: istiov1beta1.Gateway{
- 				Selector: selector,
-@@ -761,6 +764,7 @@
- 				Labels: map[string]string{
- 					networking.IngressLabelKey: "ingress",
- 				},
-+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
- 			},
- 			Spec: istiov1beta1.Gateway{
- 				Selector: selector,
-@@ -824,6 +828,7 @@
- 				Labels: map[string]string{
- 					networking.IngressLabelKey: "ingress",
- 				},
-+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
- 			},
- 			Spec: istiov1beta1.Gateway{
- 				Selector: selector,
-@@ -866,6 +871,7 @@
- 				Labels: map[string]string{
- 					networking.IngressLabelKey: "ingress",
- 				},
-+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
- 			},
- 			Spec: istiov1beta1.Gateway{
- 				Selector: selector,
-@@ -908,6 +914,7 @@
- 				Labels: map[string]string{
- 					networking.IngressLabelKey: "ingress.com",
- 				},
-+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
- 			},
- 			Spec: istiov1beta1.Gateway{
- 				Selector: selector,
 diff --git a/pkg/reconciler/ingress/ingress_test.go b/pkg/reconciler/ingress/ingress_test.go
---- a/pkg/reconciler/ingress/ingress_test.go	(revision 9914eca315000a757b0f48df69f59cdbb8f7ea23)
-+++ b/pkg/reconciler/ingress/ingress_test.go	(revision 2b701027bfe7dca09d27c709b0cc5d66069a1f5b)
-@@ -1323,8 +1323,9 @@
+--- a/pkg/reconciler/ingress/ingress_test.go	(revision 2971960b1cf6f44bbf9146e22d0e31eb253d812f)
++++ b/pkg/reconciler/ingress/ingress_test.go	(date 1707289100741)
+@@ -1525,8 +1525,9 @@
  func gateway(name, namespace string, servers []*istiov1beta1.Server, opts ...GatewayOpt) *v1beta1.Gateway {
  	gw := &v1beta1.Gateway{
  		ObjectMeta: metav1.ObjectMeta{
@@ -109,3 +56,70 @@ diff --git a/pkg/reconciler/ingress/ingress_test.go b/pkg/reconciler/ingress/ing
  		},
  		Spec: istiov1beta1.Gateway{
  			Servers: servers,
+diff --git a/pkg/reconciler/ingress/resources/gateway_test.go b/pkg/reconciler/ingress/resources/gateway_test.go
+--- a/pkg/reconciler/ingress/resources/gateway_test.go	(revision 2971960b1cf6f44bbf9146e22d0e31eb253d812f)
++++ b/pkg/reconciler/ingress/resources/gateway_test.go	(date 1707289076385)
+@@ -594,6 +594,7 @@
+ 				Name:            WildcardGatewayName(wildcardSecret.Name, "istio-system", "istio-ingressgateway"),
+ 				Namespace:       system.Namespace(),
+ 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
++				Annotations:     map[string]string{MaistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1beta1.Gateway{
+ 				Selector: selector,
+@@ -631,6 +632,7 @@
+ 				Name:            WildcardGatewayName(wildcardSecret.Name, system.Namespace(), "istio-ingressgateway"),
+ 				Namespace:       system.Namespace(),
+ 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
++				Annotations:     map[string]string{MaistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1beta1.Gateway{
+ 				Selector: selector,
+@@ -744,6 +746,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1beta1.Gateway{
+ 				Selector: selector,
+@@ -762,6 +765,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1beta1.Gateway{
+ 				Selector: selector,
+@@ -827,6 +831,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1beta1.Gateway{
+ 				Selector: selector,
+@@ -870,6 +875,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1beta1.Gateway{
+ 				Selector: selector,
+@@ -916,6 +922,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress",
+ 				},
++				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1beta1.Gateway{
+ 				Selector: selector,
+@@ -959,6 +966,7 @@
+ 				Labels: map[string]string{
+ 					networking.IngressLabelKey: "ingress.com",
+ 				},
++				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
+ 			},
+ 			Spec: istiov1beta1.Gateway{
+ 				Selector: selector,

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -164,7 +164,7 @@ var (
 		Hosts: []string{"*.example.com"},
 		Port: &istiov1beta1.Port{
 			Name:     "https",
-			Number:   443,
+			Number:   resources.ExternalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -182,13 +182,17 @@ var (
 		"gateway." + config.KnativeIngressGateway: newDomainInternal,
 		"gateway.knative-test-gateway":            originDomainInternal,
 	}
-	ingressGateway = map[v1alpha1.IngressVisibility]sets.Set[string]{
+	externalIngressGateway = map[v1alpha1.IngressVisibility]sets.Set[string]{
 		v1alpha1.IngressVisibilityExternalIP: sets.New(config.KnativeIngressGateway),
+	}
+	localIngressGateway = map[v1alpha1.IngressVisibility]sets.Set[string]{
+		v1alpha1.IngressVisibilityClusterLocal: sets.New(config.KnativeLocalGateway),
 	}
 	gateways = map[v1alpha1.IngressVisibility]sets.Set[string]{
 		v1alpha1.IngressVisibilityExternalIP: sets.New[string]("knative-test-gateway", config.KnativeIngressGateway),
 	}
-	perIngressGatewayName = resources.GatewayName(ingressWithTLS("reconciling-ingress", ingressTLS), ingressService)
+	externalIngressTLSGatewayName = resources.GatewayName(ingressWithTLS("reconciling-ingress", externalIngressTLS), v1alpha1.IngressVisibilityExternalIP, ingressService)
+	localIngressTLSGatewayName    = resources.GatewayName(ingressWithTLS("reconciling-ingress", localIngressTLS), v1alpha1.IngressVisibilityClusterLocal, ingressService)
 )
 
 var (
@@ -228,18 +232,40 @@ var (
 		Visibility: v1alpha1.IngressVisibilityClusterLocal,
 	}}
 
-	ingressTLS = []v1alpha1.IngressTLS{{
+	externalIngressTLS = []v1alpha1.IngressTLS{{
 		Hosts:           []string{"host-tls.example.com"},
 		SecretName:      "secret0",
 		SecretNamespace: "istio-system",
 	}}
 
-	// The gateway server according to ingressTLS.
-	ingressTLSServer = &istiov1beta1.Server{
+	localIngressTLS = []v1alpha1.IngressTLS{{
+		Hosts:           []string{"host-tls.test-ns.svc.cluster.local"},
+		SecretName:      "secret0",
+		SecretNamespace: "istio-system",
+	}}
+
+	// The gateway server according to externalIngressTLS.
+	externalIngressTLSServer = &istiov1beta1.Server{
 		Hosts: []string{"host-tls.example.com"},
 		Port: &istiov1beta1.Port{
 			Name:     "test-ns/reconciling-ingress:0",
-			Number:   443,
+			Number:   resources.ExternalGatewayHTTPSPort,
+			Protocol: "HTTPS",
+		},
+		Tls: &istiov1beta1.ServerTLSSettings{
+			Mode:               istiov1beta1.ServerTLSSettings_SIMPLE,
+			ServerCertificate:  "tls.crt",
+			PrivateKey:         "tls.key",
+			CredentialName:     "secret0",
+			MinProtocolVersion: istiov1beta1.ServerTLSSettings_TLSV1_2,
+		},
+	}
+
+	localIngressTLSServer = &istiov1beta1.Server{
+		Hosts: []string{"host-tls.test-ns.svc.cluster.local"},
+		Port: &istiov1beta1.Port{
+			Name:     "test-ns/reconciling-ingress:0",
+			Number:   resources.ClusterLocalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -255,7 +281,7 @@ var (
 		Hosts: []string{"host-tls.example.com"},
 		Port: &istiov1beta1.Port{
 			Name:     "http-server",
-			Number:   80,
+			Number:   resources.GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 	}
@@ -264,7 +290,7 @@ var (
 		Hosts: []string{"*"},
 		Port: &istiov1beta1.Port{
 			Name:     "http-server",
-			Number:   80,
+			Number:   resources.GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -272,12 +298,12 @@ var (
 		},
 	}
 
-	// The gateway server irrelevant to ingressTLS.
+	// The gateway server irrelevant to externalIngressTLS.
 	irrelevantServer = &istiov1beta1.Server{
 		Hosts: []string{"host-tls.example.com", "host-tls.test-ns.svc.cluster.local"},
 		Port: &istiov1beta1.Port{
 			Name:     "test:0",
-			Number:   443,
+			Number:   resources.ExternalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -292,7 +318,7 @@ var (
 		Hosts: []string{"*"},
 		Port: &istiov1beta1.Port{
 			Name:     "http-server",
-			Number:   80,
+			Number:   resources.GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 	}
@@ -712,24 +738,24 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "create Ingress Gateway to match newly created Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithTLS("reconciling-ingress", ingressTLS),
+			ingressWithTLS("reconciling-ingress", externalIngressTLS),
 			originSecret("istio-system", "secret0"),
 			ingressService,
 		},
 		WantCreates: []runtime.Object{
 			// The newly created per-Ingress Gateway.
-			gateway(perIngressGatewayName, testNS, []*istiov1beta1.Server{ingressTLSServer, ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS, []*istiov1beta1.Server{externalIngressTLSServer, ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), makeGatewayMap([]string{"test-ns/" + externalIngressTLSGatewayName}, nil)),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatus("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -770,25 +796,25 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "Update Ingress Gateway to match Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithTLS("reconciling-ingress", ingressTLS),
+			ingressWithTLS("reconciling-ingress", externalIngressTLS),
 			// The existing Ingress gateway does not have HTTPS server.
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 			originSecret("istio-system", "secret0"),
 			ingressService,
 		},
 		WantCreates: []runtime.Object{
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), makeGatewayMap([]string{"test-ns/" + externalIngressTLSGatewayName}, nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{ingressTLSServer, ingressHTTPServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			Object: gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{externalIngressTLSServer, ingressHTTPServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{
@@ -796,7 +822,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatus("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -837,7 +863,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "new Ingress using wildcard certificate",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithTLS("reconciling-ingress", ingressTLS),
+			ingressWithTLS("reconciling-ingress", externalIngressTLS),
 			wildcardCert,
 			ingressService,
 		},
@@ -845,20 +871,20 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 			wildcardGateway(resources.WildcardGatewayName(wildcardCert.Name, ingressService.Namespace, ingressService.Name), "istio-system",
 				[]*istiov1beta1.Server{wildcardTLSServer}, selector),
 			// The newly created per-Ingress Gateway.
-			gateway(perIngressGatewayName, testNS, []*istiov1beta1.Server{ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS, []*istiov1beta1.Server{ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"istio-system/" + resources.WildcardGatewayName(wildcardCert.Name, ingressService.Namespace, ingressService.Name),
-				"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), makeGatewayMap([]string{"istio-system/" + resources.WildcardGatewayName(wildcardCert.Name, ingressService.Namespace, ingressService.Name),
+				"test-ns/" + externalIngressTLSGatewayName}, nil)),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatus("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -898,7 +924,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 	}, {
 		Name: "No preinstalled Ingress service",
 		Objects: []runtime.Object{
-			ingressWithTLS("reconciling-ingress", ingressTLS),
+			ingressWithTLS("reconciling-ingress", externalIngressTLS),
 			originSecret("istio-system", "secret0"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
@@ -906,7 +932,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatus("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{{
@@ -939,13 +965,13 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "delete Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithFinalizers("reconciling-ingress", ingressTLS, []string{ingressFinalizer}, &deletionTime),
+			ingressWithFinalizers("reconciling-ingress", externalIngressTLS, []string{ingressFinalizer}, &deletionTime),
 			// ingressHTTPRedirectServer should not be deleted when deleting ingress related TLS server..
-			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, externalIngressTLSServer, ingressHTTPRedirectServer}),
 		},
 		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
-			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, externalIngressTLSServer, ingressHTTPRedirectServer}),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{ingressHTTPRedirectServer, irrelevantServer}),
@@ -963,14 +989,14 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "delete ingress with leftover secrets",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithFinalizers("reconciling-ingress", ingressTLS, []string{ingressFinalizer}, &deletionTime),
+			ingressWithFinalizers("reconciling-ingress", externalIngressTLS, []string{ingressFinalizer}, &deletionTime),
 			// ingressHTTPRedirectServer should not be deleted when deleting ingress related TLS server..
-			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, externalIngressTLSServer, ingressHTTPRedirectServer}),
 			targetSecret("istio-system", "targetSecret", resources.MakeTargetSecretLabels("secret0", "istio-system")),
 		},
 		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
-			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, externalIngressTLSServer, ingressHTTPRedirectServer}),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{ingressHTTPRedirectServer, irrelevantServer}),
@@ -1004,13 +1030,13 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			// The newly created per-Ingress Gateway.
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{withCredentialName(deepCopy(ingressTLSServer), targetSecretName), ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{withCredentialName(deepCopy(externalIngressTLSServer), targetSecretName), ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + externalIngressTLSGatewayName}, nil)),
 
 			// The secret copy under istio-system.
 			targetSecret("istio-system", targetSecretName, map[string]string{
@@ -1069,9 +1095,9 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 			ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving")),
 
 			// The newly created per-Ingress Gateway.
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{withCredentialName(deepCopy(ingressTLSServer), targetSecretName), ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{withCredentialName(deepCopy(externalIngressTLSServer), targetSecretName), ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 			ingressService,
 
@@ -1094,13 +1120,13 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 			},
 		},
 		WantCreates: []runtime.Object{
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{withCredentialName(deepCopy(ingressTLSServer), targetSecretName), ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{withCredentialName(deepCopy(externalIngressTLSServer), targetSecretName), ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + externalIngressTLSGatewayName}, nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: &corev1.Secret{
@@ -1161,18 +1187,18 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Key:     "test-ns/reconciling-ingress",
 		CmpOpts: defaultCmpOptsList,
 	}, {
-		Name:                    "Reconcile with autoTLS but cluster local visibilty, mesh only",
+		Name:                    "Reconcile with external-domain-tls but cluster local visibility, mesh only",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithTLSClusterLocal("reconciling-ingress", ingressTLS),
+			ingressWithTLSClusterLocal("reconciling-ingress", externalIngressTLS),
 			originSecret("istio-system", "secret0"),
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLSClusterLocal("reconciling-ingress", ingressTLS)), ingressGateway),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLSClusterLocal("reconciling-ingress", externalIngressTLS)), externalIngressGateway),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatusClusterLocal("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -1261,6 +1287,226 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 	}))
 }
 
+func TestReconcile_ClusterLocalDomainTLS(t *testing.T) {
+	table := TableTest{{
+		Name:                    "create local TLS gateway for an ingress with cluster-local TLS",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingressWithTLS("reconciling-ingress", localIngressTLS),
+			originSecret("istio-system", "secret0"),
+			ingressService,
+		},
+		WantCreates: []runtime.Object{
+			gateway(localIngressTLSGatewayName, testNS, []*istiov1beta1.Server{localIngressTLSServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				withLabels(gwLabels), withSelector(selector)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", localIngressTLS)), localIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				makeGatewayMap([]string{"knative-testing/" + config.KnativeIngressGateway}, []string{"knative-testing/" + config.KnativeLocalGateway, "test-ns/" + localIngressTLSGatewayName})),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithTLSAndStatus("reconciling-ingress",
+				localIngressTLS,
+				v1alpha1.IngressStatus{
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{
+								DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
+								MeshOnly:       false,
+							},
+						},
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:     v1alpha1.IngressConditionLoadBalancerReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.IngressConditionNetworkConfigured,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.IngressConditionReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}},
+					},
+				},
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
+		},
+		Key:     "test-ns/reconciling-ingress",
+		CmpOpts: defaultCmpOptsList,
+	}, {
+		Name:                    "update local TLS gateway for an ingress with cluster-local TLS",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingressWithTLS("reconciling-ingress", localIngressTLS),
+			// The existing Ingress gateway does not have HTTPS server.
+			gateway(localIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				withLabels(gwLabels), withSelector(selector)),
+			originSecret("istio-system", "secret0"),
+			ingressService,
+		},
+		WantCreates: []runtime.Object{
+			gateway(localIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				withLabels(gwLabels), withSelector(selector)),
+
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", localIngressTLS)), localIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				makeGatewayMap([]string{"knative-testing/" + config.KnativeIngressGateway}, []string{"knative-testing/" + config.KnativeLocalGateway, "test-ns/" + localIngressTLSGatewayName})),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: gateway(localIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{localIngressTLSServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				withLabels(gwLabels), withSelector(selector)),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithTLSAndStatus("reconciling-ingress",
+				localIngressTLS,
+				v1alpha1.IngressStatus{
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{
+								DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
+								MeshOnly:       false,
+							},
+						},
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:     v1alpha1.IngressConditionLoadBalancerReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.IngressConditionNetworkConfigured,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.IngressConditionReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}},
+					},
+				},
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
+		},
+		Key:     "test-ns/reconciling-ingress",
+		CmpOpts: defaultCmpOptsList,
+	}, {
+		Name:                    "delete an ingress with cluster-local TLS with leftover secrets",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingressWithFinalizers("reconciling-ingress", localIngressTLS, []string{ingressFinalizer}, &deletionTime),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer}),
+			gateway(config.KnativeLocalGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, localIngressTLSServer}),
+			targetSecret("istio-system", "targetSecret", resources.MakeTargetSecretLabels("secret0", "istio-system")),
+		},
+		WantCreates: []runtime.Object{
+			// The creation of gateways are triggered when setting up the test.
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer}),
+			gateway(config.KnativeLocalGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, localIngressTLSServer}),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: gateway(config.KnativeLocalGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer}),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("reconciling-ingress", ""),
+		},
+		WantDeletes: []clientgotesting.DeleteActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "istio-system",
+				Verb:      "delete",
+				Resource:  corev1.SchemeGroupVersion.WithResource("secrets"),
+			},
+			Name: "targetSecret",
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %s/%s", system.Namespace(), config.KnativeLocalGateway),
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "reconciling-ingress"),
+		},
+		Key:     "test-ns/reconciling-ingress",
+		CmpOpts: defaultCmpOptsList,
+	}}
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+
+		// As we use a customized resource name for Gateway CRD (i.e. `gateways`), not the one
+		// originally generated by kubernetes code generator (i.e. `gatewaies`), we have to
+		// explicitly create gateways when setting up the test per suggestion
+		// https://github.com/knative/serving/blob/a6852fc3b6cdce72b99c5d578dd64f2e03dabb8b/vendor/k8s.io/client-go/testing/fixture.go#L292
+		gateways := getGatewaysFromObjects(listers.GetIstioObjects())
+		for _, gateway := range gateways {
+			fakeistioclient.Get(ctx).NetworkingV1beta1().Gateways(gateway.Namespace).Create(ctx, gateway, metav1.CreateOptions{})
+		}
+
+		r := &Reconciler{
+			kubeclient:            kubeclient.Get(ctx),
+			istioClientSet:        istioclient.Get(ctx),
+			virtualServiceLister:  listers.GetVirtualServiceLister(),
+			destinationRuleLister: listers.GetDestinationRuleLister(),
+			gatewayLister:         listers.GetGatewayLister(),
+			secretLister:          listers.GetSecretLister(),
+			svcLister:             listers.GetK8sServiceLister(),
+			tracker:               &NullTracker{},
+			statusManager: &fakestatusmanager.FakeStatusManager{
+				FakeIsReady: func(ctx context.Context, ing *v1alpha1.Ingress) (bool, error) {
+					return true, nil
+				},
+			},
+		}
+
+		return ingressreconciler.NewReconciler(ctx, logging.FromContext(ctx), fakenetworkingclient.Get(ctx),
+			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, netconfig.IstioIngressClassName, controller.Options{
+				ConfigStore: &testConfigStore{
+					config: &config.Config{
+						Istio: &config.Istio{
+							IngressGateways: []config.Gateway{{
+								Namespace:  system.Namespace(),
+								Name:       config.KnativeIngressGateway,
+								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
+							}},
+							LocalGateways: []config.Gateway{{
+								Namespace:  system.Namespace(),
+								Name:       config.KnativeLocalGateway,
+								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
+							}},
+						},
+						Network: &netconfig.Config{
+							ClusterLocalDomainTLS: netconfig.EncryptionEnabled,
+						},
+					},
+				},
+			})
+	}))
+}
+
 func getGatewaysFromObjects(objects []runtime.Object) []*v1beta1.Gateway {
 	gateways := []*v1beta1.Gateway{}
 	for _, object := range objects {
@@ -1279,9 +1525,8 @@ type GatewayOpt func(*v1beta1.Gateway)
 func gateway(name, namespace string, servers []*istiov1beta1.Server, opts ...GatewayOpt) *v1beta1.Gateway {
 	gw := &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: map[string]string{resources.MaistraManageRouteAnnotationKey: "false"},
+			Name:      name,
+			Namespace: namespace,
 		},
 		Spec: istiov1beta1.Gateway{
 			Servers: servers,
@@ -1352,7 +1597,7 @@ func deepCopy(server *istiov1beta1.Server) *istiov1beta1.Server {
 
 func ingressTLSWithSecretNamespace(namespace string) []v1alpha1.IngressTLS {
 	result := []v1alpha1.IngressTLS{}
-	for _, tls := range ingressTLS {
+	for _, tls := range externalIngressTLS {
 		tls.SecretNamespace = namespace
 		result = append(result, tls)
 	}
@@ -1674,8 +1919,8 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	h.OnUpdate(&istioClient.Fake, "gateways", func(obj runtime.Object) HookResult {
 		createdGateway := obj.(*v1beta1.Gateway)
 		// The expected gateway should include the Istio TLS server.
-		expectedGateway := gateway(perIngressGatewayName, testNS,
-			[]*istiov1beta1.Server{ingressTLSServer, ingressHTTPServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+		expectedGateway := gateway(externalIngressTLSGatewayName, testNS,
+			[]*istiov1beta1.Server{externalIngressTLSServer, ingressHTTPServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 			withLabels(gwLabels), withSelector(selector))
 		if diff := cmp.Diff(createdGateway, expectedGateway, protocmp.Transform()); diff != "" {
 			t.Log("Unexpected Gateway (-want, +got):", diff)
@@ -1704,7 +1949,7 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	grp.Go(func() error { return ctrl.RunContext(ctx, 1) })
 
 	ingress := ingressWithTLSAndStatus("reconciling-ingress",
-		ingressTLS,
+		externalIngressTLS,
 		v1alpha1.IngressStatus{
 			PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
 				Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -1738,8 +1983,8 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 
 	// Create an Ingress gateway
 	ingressGatewayClient := istioClient.NetworkingV1beta1().Gateways(testNS)
-	ingressGateway := gateway(perIngressGatewayName, testNS,
-		[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+	ingressGateway := gateway(externalIngressTLSGatewayName, testNS,
+		[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 		withLabels(gwLabels), withSelector(selector))
 	if _, err := ingressGatewayClient.Create(ctx, ingressGateway, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Error creating gateway:", err)

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -1525,8 +1525,9 @@ type GatewayOpt func(*v1beta1.Gateway)
 func gateway(name, namespace string, servers []*istiov1beta1.Server, opts ...GatewayOpt) *v1beta1.Gateway {
 	gw := &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{resources.MaistraManageRouteAnnotationKey: "false"},
 		},
 		Spec: istiov1beta1.Gateway{
 			Servers: servers,

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -41,12 +41,13 @@ import (
 )
 
 const (
-	GatewayHTTPPort              = 80
-	ExternalGatewayHTTPSPort     = 443
-	ClusterLocalGatewayHTTPSPort = 8444
-	dns1123LabelMaxLength        = 63 // Public for testing only.
-	dns1123LabelFmt              = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
-	localGatewayPostfix          = "-local"
+	GatewayHTTPPort                 = 80
+	ExternalGatewayHTTPSPort        = 443
+	ClusterLocalGatewayHTTPSPort    = 8444
+	dns1123LabelMaxLength           = 63 // Public for testing only.
+	dns1123LabelFmt                 = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
+	localGatewayPostfix             = "-local"
+	MaistraManageRouteAnnotationKey = "maistra.io/manageRoute"
 )
 
 var httpServerPortName = "http-server"
@@ -202,6 +203,9 @@ func makeWildcardTLSGateways(originWildcardSecrets map[string]*corev1.Secret,
 				Name:            WildcardGatewayName(secret.Name, gatewayService.Namespace, gatewayService.Name),
 				Namespace:       secret.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(secret, gvk)},
+				Annotations: map[string]string{
+					MaistraManageRouteAnnotationKey: "false",
+				},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: gatewayService.Spec.Selector,
@@ -256,6 +260,9 @@ func makeIngressGateway(ing *v1alpha1.Ingress, visibility v1alpha1.IngressVisibi
 			Labels: map[string]string{
 				// We need this label to find out all Gateways of a given Ingress.
 				networking.IngressLabelKey: ing.GetName(),
+			},
+			Annotations: map[string]string{
+				MaistraManageRouteAnnotationKey: "false",
 			},
 		},
 		Spec: istiov1beta1.Gateway{

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -40,12 +40,13 @@ import (
 	"knative.dev/pkg/tracker"
 )
 
-// GatewayHTTPPort is the HTTP port the gateways listen on.
 const (
-	GatewayHTTPPort                 = 80
-	dns1123LabelMaxLength           = 63 // Public for testing only.
-	dns1123LabelFmt                 = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
-	MaistraManageRouteAnnotationKey = "maistra.io/manageRoute"
+	GatewayHTTPPort              = 80
+	ExternalGatewayHTTPSPort     = 443
+	ClusterLocalGatewayHTTPSPort = 8444
+	dns1123LabelMaxLength        = 63 // Public for testing only.
+	dns1123LabelFmt              = "[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?"
+	localGatewayPostfix          = "-local"
 )
 
 var httpServerPortName = "http-server"
@@ -106,7 +107,8 @@ func SortServers(servers []*istiov1beta1.Server) []*istiov1beta1.Server {
 }
 
 // MakeIngressTLSGateways creates Gateways that have only TLS servers for a given Ingress.
-func MakeIngressTLSGateways(ctx context.Context, ing *v1alpha1.Ingress, ingressTLS []v1alpha1.IngressTLS, originSecrets map[string]*corev1.Secret, svcLister corev1listers.ServiceLister) ([]*v1beta1.Gateway, error) {
+func MakeIngressTLSGateways(ctx context.Context, ing *v1alpha1.Ingress, visibility v1alpha1.IngressVisibility,
+	ingressTLS []v1alpha1.IngressTLS, originSecrets map[string]*corev1.Secret, svcLister corev1listers.ServiceLister) ([]*v1beta1.Gateway, error) {
 	// No need to create Gateway if there is no related ingress TLS.
 	if len(ingressTLS) == 0 {
 		return []*v1beta1.Gateway{}, nil
@@ -117,17 +119,17 @@ func MakeIngressTLSGateways(ctx context.Context, ing *v1alpha1.Ingress, ingressT
 	}
 	gateways := make([]*v1beta1.Gateway, len(gatewayServices))
 	for i, gatewayService := range gatewayServices {
-		servers, err := MakeTLSServers(ing, ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), gatewayService.Namespace, originSecrets)
+		servers, err := MakeTLSServers(ing, visibility, ingressTLS, gatewayService.Namespace, originSecrets)
 		if err != nil {
 			return nil, err
 		}
-		gateways[i] = makeIngressGateway(ing, gatewayService.Spec.Selector, servers, gatewayService)
+		gateways[i] = makeIngressGateway(ing, visibility, gatewayService.Spec.Selector, servers, gatewayService)
 	}
 	return gateways, nil
 }
 
-// MakeIngressGateways creates Gateways with given Servers for a given Ingress.
-func MakeIngressGateways(ctx context.Context, ing *v1alpha1.Ingress, servers []*istiov1beta1.Server, svcLister corev1listers.ServiceLister) ([]*v1beta1.Gateway, error) {
+// MakeExternalIngressGateways creates Gateways with given Servers for a given Ingress.
+func MakeExternalIngressGateways(ctx context.Context, ing *v1alpha1.Ingress, servers []*istiov1beta1.Server, svcLister corev1listers.ServiceLister) ([]*v1beta1.Gateway, error) {
 	gatewayServices, err := getGatewayServices(ctx, svcLister)
 	if err != nil {
 		return nil, err
@@ -137,7 +139,7 @@ func MakeIngressGateways(ctx context.Context, ing *v1alpha1.Ingress, servers []*
 		if err != nil {
 			return nil, err
 		}
-		gateways[i] = makeIngressGateway(ing, gatewayService.Spec.Selector, servers, gatewayService)
+		gateways[i] = makeIngressGateway(ing, v1alpha1.IngressVisibilityExternalIP, gatewayService.Spec.Selector, servers, gatewayService)
 	}
 	return gateways, nil
 }
@@ -182,7 +184,7 @@ func makeWildcardTLSGateways(originWildcardSecrets map[string]*corev1.Secret,
 			Hosts: hosts,
 			Port: &istiov1beta1.Port{
 				Name:     "https",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -200,9 +202,6 @@ func makeWildcardTLSGateways(originWildcardSecrets map[string]*corev1.Secret,
 				Name:            WildcardGatewayName(secret.Name, gatewayService.Namespace, gatewayService.Name),
 				Namespace:       secret.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(secret, gvk)},
-				Annotations: map[string]string{
-					MaistraManageRouteAnnotationKey: "false",
-				},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: gatewayService.Spec.Selector,
@@ -248,18 +247,15 @@ func GatewayRef(gw *v1beta1.Gateway) tracker.Reference {
 	}
 }
 
-func makeIngressGateway(ing *v1alpha1.Ingress, selector map[string]string, servers []*istiov1beta1.Server, gatewayService *corev1.Service) *v1beta1.Gateway {
+func makeIngressGateway(ing *v1alpha1.Ingress, visibility v1alpha1.IngressVisibility, selector map[string]string, servers []*istiov1beta1.Server, gatewayService *corev1.Service) *v1beta1.Gateway {
 	return &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            GatewayName(ing, gatewayService),
+			Name:            GatewayName(ing, visibility, gatewayService),
 			Namespace:       ing.GetNamespace(),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing)},
 			Labels: map[string]string{
-				// We need this label to find out all of Gateways of a given Ingress.
+				// We need this label to find out all Gateways of a given Ingress.
 				networking.IngressLabelKey: ing.GetName(),
-			},
-			Annotations: map[string]string{
-				MaistraManageRouteAnnotationKey: "false",
 			},
 		},
 		Spec: istiov1beta1.Gateway{
@@ -287,13 +283,16 @@ func getGatewayServices(ctx context.Context, svcLister corev1listers.ServiceList
 
 // GatewayName create a name for the Gateway that is built based on the given Ingress and bonds to the
 // given ingress gateway service.
-func GatewayName(accessor kmeta.Accessor, gatewaySvc *corev1.Service) string {
+func GatewayName(accessor kmeta.Accessor, visibility v1alpha1.IngressVisibility, gatewaySvc *corev1.Service) string {
 	prefix := accessor.GetName()
 	if !isDNS1123Label(prefix) {
 		prefix = fmt.Sprint(adler32.Checksum([]byte(prefix)))
 	}
 
 	gatewayServiceKey := fmt.Sprintf("%s/%s", gatewaySvc.Namespace, gatewaySvc.Name)
+	if visibility == v1alpha1.IngressVisibilityClusterLocal {
+		gatewayServiceKey += localGatewayPostfix
+	}
 	gatewayServiceKeyChecksum := fmt.Sprint(adler32.Checksum([]byte(gatewayServiceKey)))
 
 	// Ensure that the overall gateway name still is a DNS1123 label
@@ -306,8 +305,19 @@ func GatewayName(accessor kmeta.Accessor, gatewaySvc *corev1.Service) string {
 }
 
 // MakeTLSServers creates the expected Gateway TLS `Servers` based on the given IngressTLS.
-func MakeTLSServers(ing *v1alpha1.Ingress, ingressTLS []v1alpha1.IngressTLS, gatewayServiceNamespace string, originSecrets map[string]*corev1.Secret) ([]*istiov1beta1.Server, error) {
+func MakeTLSServers(ing *v1alpha1.Ingress, visibility v1alpha1.IngressVisibility, ingressTLS []v1alpha1.IngressTLS, gatewayServiceNamespace string, originSecrets map[string]*corev1.Secret) ([]*istiov1beta1.Server, error) {
 	servers := make([]*istiov1beta1.Server, len(ingressTLS))
+
+	var port uint32
+	switch {
+	case visibility == v1alpha1.IngressVisibilityExternalIP:
+		port = ExternalGatewayHTTPSPort
+	case visibility == v1alpha1.IngressVisibilityClusterLocal:
+		port = ClusterLocalGatewayHTTPSPort
+	default:
+		return nil, fmt.Errorf("invalid ingress visibility: %v", visibility)
+	}
+
 	// TODO(zhiminx): for the hosts that does not included in the IngressTLS but listed in the IngressRule,
 	// do we consider them as hosts for HTTP?
 	for i, tls := range ingressTLS {
@@ -326,7 +336,7 @@ func MakeTLSServers(ing *v1alpha1.Ingress, ingressTLS []v1alpha1.IngressTLS, gat
 			Hosts: tls.Hosts,
 			Port: &istiov1beta1.Port{
 				Name:     fmt.Sprintf(portNamePrefix(ing.GetNamespace(), ing.GetName())+":%d", i),
-				Number:   443,
+				Number:   port,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -375,10 +385,10 @@ func MakeHTTPServer(httpOption v1alpha1.HTTPOption, hosts []string) *istiov1beta
 }
 
 // GetNonWildcardIngressTLS gets Ingress TLS that do not reference wildcard certificates.
-func GetNonWildcardIngressTLS(ingressTLS []v1alpha1.IngressTLS, nonWildcardSecrest map[string]*corev1.Secret) []v1alpha1.IngressTLS {
+func GetNonWildcardIngressTLS(ingressTLS []v1alpha1.IngressTLS, nonWildcardSecrets map[string]*corev1.Secret) []v1alpha1.IngressTLS {
 	result := []v1alpha1.IngressTLS{}
 	for _, tls := range ingressTLS {
-		if _, ok := nonWildcardSecrest[secretKey(tls)]; ok {
+		if _, ok := nonWildcardSecrets[secretKey(tls)]; ok {
 			result = append(result, tls)
 		}
 	}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -80,7 +80,7 @@ var servers = []*istiov1beta1.Server{{
 	Hosts: []string{"host1.example.com"},
 	Port: &istiov1beta1.Port{
 		Name:     "test-ns/ingress:0",
-		Number:   443,
+		Number:   ExternalGatewayHTTPSPort,
 		Protocol: "HTTPS",
 	},
 	Tls: &istiov1beta1.ServerTLSSettings{
@@ -92,7 +92,7 @@ var servers = []*istiov1beta1.Server{{
 	Hosts: []string{"host2.example.com"},
 	Port: &istiov1beta1.Port{
 		Name:     "test-ns/non-ingress:0",
-		Number:   443,
+		Number:   ExternalGatewayHTTPSPort,
 		Protocol: "HTTPS",
 	},
 	Tls: &istiov1beta1.ServerTLSSettings{
@@ -106,7 +106,7 @@ var httpServer = istiov1beta1.Server{
 	Hosts: []string{"*"},
 	Port: &istiov1beta1.Port{
 		Name:     httpServerPortName,
-		Number:   80,
+		Number:   GatewayHTTPPort,
 		Protocol: "HTTP",
 	},
 }
@@ -127,7 +127,7 @@ var modifiedDefaultTLSServer = istiov1beta1.Server{
 	Hosts: []string{"added.by.user.example.com"},
 	Port: &istiov1beta1.Port{
 		Name:     "https",
-		Number:   443,
+		Number:   ExternalGatewayHTTPSPort,
 		Protocol: "HTTPS",
 	},
 	Tls: &istiov1beta1.ServerTLSSettings{
@@ -183,7 +183,7 @@ func TestGetServers(t *testing.T) {
 		Hosts: []string{"host1.example.com"},
 		Port: &istiov1beta1.Port{
 			Name:     "test-ns/ingress:0",
-			Number:   443,
+			Number:   ExternalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -206,7 +206,7 @@ func TestGetHTTPServer(t *testing.T) {
 		Hosts: []string{"*"},
 		Port: &istiov1beta1.Port{
 			Name:     httpServerPortName,
-			Number:   80,
+			Number:   GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 	}
@@ -233,7 +233,7 @@ func TestMakeTLSServers(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -254,7 +254,7 @@ func TestMakeTLSServers(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -275,7 +275,7 @@ func TestMakeTLSServers(t *testing.T) {
 			Port: &istiov1beta1.Port{
 				// port name is created with <namespace>/<name>
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -295,7 +295,7 @@ func TestMakeTLSServers(t *testing.T) {
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			servers, err := MakeTLSServers(c.ci, c.ci.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), c.gatewayServiceNamespace, c.originSecrets)
+			servers, err := MakeTLSServers(c.ci, v1alpha1.IngressVisibilityExternalIP, c.ci.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), c.gatewayServiceNamespace, c.originSecrets)
 			if (err != nil) != c.wantErr {
 				t.Fatalf("Test: %s; MakeServers error = %v, WantErr %v", c.name, err, c.wantErr)
 			}
@@ -322,7 +322,7 @@ func TestMakeHTTPServer(t *testing.T) {
 			Hosts: []string{"*"},
 			Port: &istiov1beta1.Port{
 				Name:     httpServerPortName,
-				Number:   80,
+				Number:   GatewayHTTPPort,
 				Protocol: "HTTP",
 			},
 		},
@@ -333,7 +333,7 @@ func TestMakeHTTPServer(t *testing.T) {
 			Hosts: []string{"*"},
 			Port: &istiov1beta1.Port{
 				Name:     httpServerPortName,
-				Number:   80,
+				Number:   GatewayHTTPPort,
 				Protocol: "HTTP",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -364,7 +364,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -377,7 +377,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host-new.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -394,7 +394,7 @@ func TestUpdateGateway(t *testing.T) {
 					Hosts: []string{"host-new.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -406,7 +406,7 @@ func TestUpdateGateway(t *testing.T) {
 					Hosts: []string{"host2.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/non-ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -423,7 +423,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -441,7 +441,7 @@ func TestUpdateGateway(t *testing.T) {
 					Hosts: []string{"host2.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/non-ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -455,12 +455,12 @@ func TestUpdateGateway(t *testing.T) {
 	}, {
 		name: "Delete servers from Gateway and no real servers are left",
 
-		// All of the servers in the original gateway will be deleted.
+		// All the servers in the original gateway will be deleted.
 		existingServers: []*istiov1beta1.Server{{
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -472,7 +472,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host2.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/non-ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -491,7 +491,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -509,7 +509,7 @@ func TestUpdateGateway(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -528,7 +528,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "clusteringress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -545,7 +545,7 @@ func TestUpdateGateway(t *testing.T) {
 						Hosts: []string{"host1.example.com"},
 						Port: &istiov1beta1.Port{
 							Name:     "clusteringress:0",
-							Number:   443,
+							Number:   ExternalGatewayHTTPSPort,
 							Protocol: "HTTPS",
 						},
 						Tls: &istiov1beta1.ServerTLSSettings{
@@ -594,7 +594,6 @@ func TestMakeWildcardGateways(t *testing.T) {
 				Name:            WildcardGatewayName(wildcardSecret.Name, "istio-system", "istio-ingressgateway"),
 				Namespace:       system.Namespace(),
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
-				Annotations:     map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -602,7 +601,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 					Hosts: []string{"*.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "https",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -632,7 +631,6 @@ func TestMakeWildcardGateways(t *testing.T) {
 				Name:            WildcardGatewayName(wildcardSecret.Name, system.Namespace(), "istio-ingressgateway"),
 				Namespace:       system.Namespace(),
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
-				Annotations:     map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -640,7 +638,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 					Hosts: []string{"*.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "https",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -727,7 +725,7 @@ func TestGetQualifiedGatewayNames(t *testing.T) {
 	}
 }
 
-func TestMakeIngressGateways(t *testing.T) {
+func TestMakeExternalIngressGateways(t *testing.T) {
 	cases := []struct {
 		name    string
 		ia      *v1alpha1.Ingress
@@ -746,7 +744,6 @@ func TestMakeIngressGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
-				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -765,7 +762,6 @@ func TestMakeIngressGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
-				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -789,9 +785,9 @@ func TestMakeIngressGateways(t *testing.T) {
 			},
 		})
 		t.Run(c.name, func(t *testing.T) {
-			got, err := MakeIngressGateways(ctx, c.ia, c.servers, svcLister)
+			got, err := MakeExternalIngressGateways(ctx, c.ia, c.servers, svcLister)
 			if (err != nil) != c.wantErr {
-				t.Fatalf("Test: %s; MakeIngressTLSGateways error = %v, WantErr %v", c.name, err, c.wantErr)
+				t.Fatalf("Test: %s; MakeExternalIngressGateways error = %v, WantErr %v", c.name, err, c.wantErr)
 			}
 			if diff := cmp.Diff(c.want, got, defaultGatewayCmpOpts); diff != "" {
 				t.Error("Unexpected Gateways (-want, +got):", diff)
@@ -804,6 +800,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 	cases := []struct {
 		name           string
 		ia             *v1alpha1.Ingress
+		visibility     v1alpha1.IngressVisibility
 		originSecrets  map[string]*corev1.Secret
 		gatewayService *corev1.Service
 		want           []*v1beta1.Gateway
@@ -811,6 +808,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 	}{{
 		name:          "happy path: secret namespace is the different from the gateway service namespace",
 		ia:            &ingressResource,
+		visibility:    v1alpha1.IngressVisibilityExternalIP,
 		originSecrets: originSecrets,
 		gatewayService: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -829,7 +827,6 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
-				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -837,7 +834,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -854,6 +851,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 		name:          "happy path: secret namespace is the same as the gateway service namespace",
 		ia:            &ingressResource,
 		originSecrets: originSecrets,
+		visibility:    v1alpha1.IngressVisibilityExternalIP,
 		// The namespace of gateway service is the same as the secrets.
 		gatewayService: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -872,7 +870,6 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
-				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -880,7 +877,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -894,9 +891,56 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 			},
 		}},
 	}, {
+		name: "happy path with cluster-local visibility",
+		ia: func() *v1alpha1.Ingress {
+			ing := ingressResource.DeepCopy()
+			ing.Spec.Rules[0].Visibility = v1alpha1.IngressVisibilityClusterLocal
+			return ing
+		}(),
+		visibility:    v1alpha1.IngressVisibilityClusterLocal,
+		originSecrets: originSecrets,
+		gatewayService: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: "istio-system",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: selector,
+			},
+		},
+		want: []*v1beta1.Gateway{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("ingress-%d", adler32.Checksum([]byte("istio-system/istio-ingressgateway-local"))),
+				Namespace:       "test-ns",
+				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(&ingressResource)},
+				Labels: map[string]string{
+					networking.IngressLabelKey: "ingress",
+				},
+			},
+			Spec: istiov1beta1.Gateway{
+				Selector: selector,
+				Servers: []*istiov1beta1.Server{{
+					Hosts: []string{"host1.example.com"},
+					Port: &istiov1beta1.Port{
+						Name:     "test-ns/ingress:0",
+						Number:   ClusterLocalGatewayHTTPSPort,
+						Protocol: "HTTPS",
+					},
+					Tls: &istiov1beta1.ServerTLSSettings{
+						Mode:               istiov1beta1.ServerTLSSettings_SIMPLE,
+						ServerCertificate:  corev1.TLSCertKey,
+						PrivateKey:         corev1.TLSPrivateKeyKey,
+						CredentialName:     targetSecret(&secret, &ingressResource),
+						MinProtocolVersion: istiov1beta1.ServerTLSSettings_TLSV1_2,
+					},
+				}},
+			},
+		}},
+	}, {
 		name: "ingress name has dot",
 
 		ia:            &ingressResourceWithDotName,
+		visibility:    v1alpha1.IngressVisibilityExternalIP,
 		originSecrets: originSecrets,
 		gatewayService: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -915,7 +959,6 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress.com",
 				},
-				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -923,7 +966,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     fmt.Sprintf("test-ns/%d:0", adler32.Checksum([]byte("ingress.com"))),
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -939,6 +982,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 	}, {
 		name:          "error to make gateway because of incorrect originSecrets",
 		ia:            &ingressResource,
+		visibility:    v1alpha1.IngressVisibilityExternalIP,
 		originSecrets: map[string]*corev1.Secret{},
 		gatewayService: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -968,7 +1012,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 			},
 		})
 		t.Run(c.name, func(t *testing.T) {
-			got, err := MakeIngressTLSGateways(ctx, c.ia, c.ia.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), c.originSecrets, svcLister)
+			got, err := MakeIngressTLSGateways(ctx, c.ia, c.visibility, c.ia.GetIngressTLSForVisibility(c.visibility), c.originSecrets, svcLister)
 			if (err != nil) != c.wantErr {
 				t.Fatalf("Test: %s; MakeIngressTLSGateways error = %v, WantErr %v", c.name, err, c.wantErr)
 			}
@@ -1006,9 +1050,15 @@ func TestGatewayName(t *testing.T) {
 	}
 
 	want := fmt.Sprintf("ingress-%d", adler32.Checksum([]byte("istio-system/gateway")))
-	got := GatewayName(ingress, svc)
+	got := GatewayName(ingress, v1alpha1.IngressVisibilityExternalIP, svc)
 	if got != want {
-		t.Errorf("Unexpected gateway name. want %q, got %q", want, got)
+		t.Errorf("Unexpected external gateway name. want %q, got %q", want, got)
+	}
+
+	want = fmt.Sprintf("ingress-%d", adler32.Checksum([]byte("istio-system/gateway-local")))
+	got = GatewayName(ingress, v1alpha1.IngressVisibilityClusterLocal, svc)
+	if got != want {
+		t.Errorf("Unexpected local gateway name. want %q, got %q", want, got)
 	}
 }
 
@@ -1027,7 +1077,7 @@ func TestGatewayNameLongIngressName(t *testing.T) {
 	}
 
 	want := fmt.Sprintf("areallyverylongdomainnamethatexcd8923dee789a086a0ac4-%d", adler32.Checksum([]byte("istio-system/gateway")))
-	got := GatewayName(ingress, svc)
+	got := GatewayName(ingress, "", svc)
 	if got != want {
 		t.Errorf("Unexpected gateway name. want %q, got %q", want, got)
 	}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -594,6 +594,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 				Name:            WildcardGatewayName(wildcardSecret.Name, "istio-system", "istio-ingressgateway"),
 				Namespace:       system.Namespace(),
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
+				Annotations:     map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -631,6 +632,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 				Name:            WildcardGatewayName(wildcardSecret.Name, system.Namespace(), "istio-ingressgateway"),
 				Namespace:       system.Namespace(),
 				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, secretGVK)},
+				Annotations:     map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -744,6 +746,7 @@ func TestMakeExternalIngressGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -762,6 +765,7 @@ func TestMakeExternalIngressGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -827,6 +831,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -870,6 +875,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -916,6 +922,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress",
 				},
+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,
@@ -959,6 +966,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 				Labels: map[string]string{
 					networking.IngressLabelKey: "ingress.com",
 				},
+				Annotations: map[string]string{MaistraManageRouteAnnotationKey: "false"},
 			},
 			Spec: istiov1beta1.Gateway{
 				Selector: selector,

--- a/pkg/reconciler/ingress/resources/secret.go
+++ b/pkg/reconciler/ingress/resources/secret.go
@@ -33,11 +33,11 @@ import (
 	"knative.dev/pkg/tracker"
 )
 
-// GetSecrets gets the all of the secrets referenced by the given Ingress, and
-// returns a map whose key is the a secret namespace/name key and value is pointer of the secret.
-func GetSecrets(ing *v1alpha1.Ingress, secretLister corev1listers.SecretLister) (map[string]*corev1.Secret, error) {
+// GetSecrets gets the all the secrets referenced by the given Ingress and visibility.
+// Returns a map whose key is the secret namespace/name key and value is pointer of the secret.
+func GetSecrets(ing *v1alpha1.Ingress, visibility v1alpha1.IngressVisibility, secretLister corev1listers.SecretLister) (map[string]*corev1.Secret, error) {
 	secrets := map[string]*corev1.Secret{}
-	for _, tls := range ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP) {
+	for _, tls := range ing.GetIngressTLSForVisibility(visibility) {
 		ref := secretKey(tls)
 		if _, ok := secrets[ref]; ok {
 			continue
@@ -72,7 +72,7 @@ func MakeSecrets(ctx context.Context, originSecrets map[string]*corev1.Secret, a
 	return secrets, nil
 }
 
-// MakeWildcardSecrets copies wildcard certificates from origin namespace to the namespace of gateway servicess so they could
+// MakeWildcardSecrets copies wildcard certificates from origin namespace to the namespace of gateway services, so they can be
 // consumed by Istio ingress.
 func MakeWildcardSecrets(ctx context.Context, originWildcardCerts map[string]*corev1.Secret) ([]*corev1.Secret, error) {
 	nameNamespaces, err := GetIngressGatewaySvcNameNamespaces(ctx)

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -114,7 +114,7 @@ func TestGetSecrets(t *testing.T) {
 	for _, c := range cases {
 		createSecret(c.secret)
 		t.Run(c.name, func(t *testing.T) {
-			secrets, err := GetSecrets(c.ci, secretClient.Lister())
+			secrets, err := GetSecrets(c.ci, v1alpha1.IngressVisibilityExternalIP, secretClient.Lister())
 			if (err != nil) != c.wantErr {
 				t.Fatalf("Test: %s; GetSecrets error = %v, WantErr %v", c.name, err, c.wantErr)
 			}


### PR DESCRIPTION
# Changes
- Back-ports https://github.com/knative-extensions/net-istio/pull/1228 to release-1.13
- Updates the patch to reflect upstream changes

Note: This patch does not need to be cherry-picked. Upstream 1.14 will have it and we do not need it in <1.13.

/assign @skonto 