### PR TITLE
[RELEASE-1.15] Back-port upstream istio.sidecar.inject labels

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -28,12 +28,11 @@ spec:
       app: net-istio-controller
   template:
     metadata:
-      annotations:
+      labels:
         # This must be outside of the mesh to probe the gateways.
         # NOTE: this is allowed here and not elsewhere because
         # this is the Istio controller, and so it may be Istio-aware.
         sidecar.istio.io/inject: "false"
-      labels:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving

--- a/openshift/release/artifacts/net-istio-core.yaml
+++ b/openshift/release/artifacts/net-istio-core.yaml
@@ -181,12 +181,11 @@ spec:
       app: net-istio-controller
   template:
     metadata:
-      annotations:
+      labels:
         # This must be outside of the mesh to probe the gateways.
         # NOTE: this is allowed here and not elsewhere because
         # this is the Istio controller, and so it may be Istio-aware.
         sidecar.istio.io/inject: "false"
-      labels:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving


### PR DESCRIPTION
**What this PR does / why we need it**:
Back-ports:
- https://github.com/knative-extensions/net-istio/commit/8d4a09ee28c54847e766d9b61fb299e9c5ef3fcf

**Which issue(s) this PR fixes**:

JIRA: https://issues.redhat.com/browse/SRVKS-1273

**Does this PR needs for other branches**:
No, will be included from 1.16+ from upstream

**Does this PR (patch) needs to update/drop in the future?**:
No

/assign @skonto 