### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for net-istio-webhook-115

### DIFF
--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -30,6 +30,7 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Net Istio Webhook" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Net Istio Webhook" \
       io.k8s.description="Red Hat OpenShift Serverless Net Istio Webhook" \
-      io.openshift.tags="webhook"
+      io.openshift.tags="webhook" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8"
 
 ENTRYPOINT ["/ko-app/webhook"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
