### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for net-istio-controller-115

### DIFF
--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -28,6 +28,7 @@ LABEL \
       summary="Red Hat OpenShift Serverless 1 Net Istio Controller" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Net Istio Controller" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Net Istio Controller" \
       io.k8s.description="Red Hat OpenShift Serverless Net Istio Controller" \
       io.openshift.tags="controller"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
