### PR TITLE
[release-v1.17][SRVKS-1351] Allow unknown field to support k8s 1.35

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.30.x
         - v1.31.x
+        - v1.35.x
 
         test-suite:
         - ./test/conformance
@@ -37,12 +37,12 @@ jobs:
     - uses: knative/actions/setup-go@main
     - uses: ko-build/setup-ko@v0.6
     - uses: actions/checkout@v4
-    - uses: chainguard-dev/actions/setup-kind@v1.4.2
+    - uses: chainguard-dev/actions/setup-kind@v1.6.22
       id: kind
       with:
         k8s-version: ${{ matrix.k8s-version }}
         kind-worker-count: 1
-        cluster-suffix: "${CLUSTER_SUFFIX}"
+        cluster-suffix: c${{ github.run_id }}.local
 
     - name: Install Knative net-istio
       run: |

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -73,7 +73,8 @@ func NewDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) 
 		},
 
 		// Whether to disallow unknown fields.
-		true,
+		// SRVKS-1351: allow unknown fields to support k8s 1.35
+		false,
 	)
 }
 


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/SRVKS-1351

Fixes:
```
net-istio webhook rejects Deployment status updates on K8s 1.35 (OCP 4.22) due to unknown field "terminatingReplicas"
```

/cc @maschmid @Kaustubh-pande 